### PR TITLE
Fixed scroll bug for tall sidebars

### DIFF
--- a/js/thedaily-exhibits.js
+++ b/js/thedaily-exhibits.js
@@ -10,7 +10,7 @@
 
         var sidebarScroller = function() {
             $window.scroll(function() {
-                if ($window.scrollTop() > offset.top) {
+                if ($window.scrollTop() > offset.top && $window.height() > ($sidebar.height() + offset.top) ) {
                     $sidebar.stop().animate({
                         marginTop: $window.scrollTop() - offset.top + topPadding
                     });


### PR DESCRIPTION
Automatic scrolling was causing problems on pages where the scrollbar height was grater than that of page content.  